### PR TITLE
Support large body uploads with repeated read callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: rust
 cache: cargo
+
+# Configure local httpbin instance:
+services:
+  - docker
+before_install:
+  - docker run -d -p 4662:80 kennethreitz/httpbin

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -114,6 +114,24 @@ fn test_basic_auth() {
     assert!(response.is_success(), "authorized request should succeed");
 }
 
+#[test]
+fn test_large_body() {
+    // By default cURL buffers seem to be 2^16 bytes in size. The test
+    // size is therefore 2^16+1.
+    const BODY_SIZE: usize = 65537;
+
+    let resp = Request::post("http://127.0.0.1:4662/post")
+        .body("application/octet-stream", &[0; BODY_SIZE])
+        .send().expect("sending request")
+        .as_json::<Value>().expect("JSON deserialisation");
+
+    // httpbin returns the uploaded data as a string in the `data`
+    // field.
+    let data = resp.body.get("data").unwrap().as_str().unwrap();
+
+    assert_eq!(BODY_SIZE, data.len(), "uploaded data length should be correct");
+}
+
 // Tests for various other features.
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,12 +1,19 @@
+// All tests expect an httpbin instance to be available at
+// `http://localhost:4662`.
+//
+// This is easily spun up using Docker by running:
+//
+//    docker run --rm -p 4662:80 kennethreitz/httpbin
+
 use super::*;
 use serde_json::{Value, json};
 
 // These tests check whether the correct HTTP method is used in the
-// requests. httpbin will return 405-statuses for incorrect methods.
+// requests.
 
 #[test]
 fn test_http_get() {
-    let resp = Request::get("https://httpbin.org/get")
+    let resp = Request::get("http://127.0.0.1:4662/get")
         .send().expect("failed to send request");
 
     assert!(resp.is_success(), "request should have succeeded");
@@ -14,7 +21,7 @@ fn test_http_get() {
 
 #[test]
 fn test_http_delete() {
-    let resp = Request::delete("https://httpbin.org/delete")
+    let resp = Request::delete("http://127.0.0.1:4662/delete")
         .send().expect("failed to send request");
 
     assert_eq!(200, resp.status, "response status should be 200 OK");
@@ -22,7 +29,7 @@ fn test_http_delete() {
 
 #[test]
 fn test_http_put() {
-    let resp = Request::put("https://httpbin.org/put")
+    let resp = Request::put("http://127.0.0.1:4662/put")
         .send().expect("failed to send request");
 
     assert_eq!(200, resp.status, "response status should be 200 OK");
@@ -30,7 +37,7 @@ fn test_http_put() {
 
 #[test]
 fn test_http_patch() {
-    let resp = Request::patch("https://httpbin.org/patch")
+    let resp = Request::patch("http://127.0.0.1:4662/patch")
         .send().expect("failed to send request");
 
     assert_eq!(200, resp.status, "response status should be 200 OK");
@@ -42,7 +49,7 @@ fn test_http_patch() {
 #[test]
 fn test_http_post() {
     let body = "test body";
-    let response = Request::post("https://httpbin.org/post")
+    let response = Request::post("http://127.0.0.1:4662/post")
         .user_agent("crimp test suite").expect("failed to set user-agent")
         .timeout(Duration::from_secs(5)).expect("failed to set request timeout")
         .body("text/plain", &body.as_bytes())
@@ -69,7 +76,7 @@ fn test_http_post_json() {
         "purpose": "testing!"
     });
 
-    let response = Request::post("https://httpbin.org/post")
+    let response = Request::post("http://127.0.0.1:4662/post")
         .user_agent("crimp test suite").expect("failed to set user-agent")
         .timeout(Duration::from_secs(5)).expect("failed to set request timeout")
         .json(&body).expect("request serialization failed")
@@ -96,7 +103,7 @@ fn test_http_post_json() {
 
 #[test]
 fn test_bearer_auth() {
-    let response = Request::get("https://httpbin.org/bearer")
+    let response = Request::get("http://127.0.0.1:4662/bearer")
         .bearer_auth("some-token").expect("failed to set auth header")
         .send().expect("failed to send request");
 
@@ -105,7 +112,7 @@ fn test_bearer_auth() {
 
 #[test]
 fn test_basic_auth() {
-    let request = Request::get("https://httpbin.org/basic-auth/alan_watts/oneness");
+    let request = Request::get("http://127.0.0.1:4662/basic-auth/alan_watts/oneness");
 
     let response = request
         .basic_auth("alan_watts", "oneness").expect("failed to set auth header")
@@ -136,7 +143,7 @@ fn test_large_body() {
 
 #[test]
 fn test_error_for_status() {
-    let response = Request::get("https://httpbin.org/patch")
+    let response = Request::get("http://127.0.0.1:4662/patch")
         .send().expect("failed to send request")
         .error_for_status(|resp| format!("Response error code: {}", resp.status));
 


### PR DESCRIPTION
When uploading larger amounts of data, cURL will call the read
callback incrementally multiple times to receive all the expected
data.

Previously if the size of the data to upload exceeded the size of the
initial buffer provided by cURL, the write (and thus the request)
would fail.

This changes the logic to write the data in chunks of a size that are
acceptable to cURL.